### PR TITLE
Mdx header components

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,9 +1,13 @@
 import type { MDXComponents } from "mdx/types";
 import p from "./src/components/p";
+import h1 from "./src/components/h1";
+import h2 from "./src/components/h2";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
     p,
+    h1,
+    h2,
   };
 }

--- a/src/components/BlogPostLayout.tsx
+++ b/src/components/BlogPostLayout.tsx
@@ -11,7 +11,10 @@ export default function BlogPostLayout({
     <div className="w-full flex justify-center align-center">
       <div className="lg:w-8/12 md:w-9/12 w-full p-2 mx-auto sm:px-4">
         <header className="flex justify-between items-center pt-12 mb-8">
-          <Link href="/blog" className="text-main-accent hover:underline">
+          <Link
+            href="/blog"
+            className="transition-colors duration-300 ease-in-out hover:text-main-accent-light dark:hover:text-main-accent rounded-md text-sx"
+          >
             ← Back to Blog
           </Link>
           <ThemeToggle />

--- a/src/components/h1.tsx
+++ b/src/components/h1.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode, HTMLAttributes } from "react";
+
+interface CustomH1Props extends HTMLAttributes<HTMLHeadingElement> {
+  children?: ReactNode;
+}
+
+const CustomH1: React.FC<CustomH1Props> = ({ children, ...props }) => (
+  <h1
+    className="text-2xl font-semibold text-main-accent-light dark:text-main-accent transition-colors duration-300 ease-in-out"
+    {...props}
+  >
+    {children}
+  </h1>
+);
+
+export default CustomH1;

--- a/src/components/h2.tsx
+++ b/src/components/h2.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode, HTMLAttributes } from "react";
+
+interface CustomH2Props extends HTMLAttributes<HTMLHeadingElement> {
+  children?: ReactNode;
+}
+
+const CustomH2: React.FC<CustomH2Props> = ({ children, ...props }) => (
+  <h2
+    className="text-2xl font-semibold my-4 text-black dark:text-white"
+    {...props}
+  >
+    {children}
+  </h2>
+);
+
+export default CustomH2;


### PR DESCRIPTION
This PR will:
- Fix style inconsistencies between the main header and the blog one.
- Add H1 header component to the custom MDX rendering list
- Add H2 header component to the custom MDX rendering list